### PR TITLE
truncate when overwriting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 serde_yaml = "0.8.14"
 toml = "0.5"
-derive_from_as = "0.1.0"
+derive_from_as = {path = "derive_from_as"}
 from_as_file = "0.1.0"

--- a/derive_from_as/src/lib.rs
+++ b/derive_from_as/src/lib.rs
@@ -80,6 +80,7 @@ pub fn derive_as_file(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                     let mut file = std::fs::OpenOptions::new()
                         .create(true)
                         .write(true)
+                        .truncate(true)
                         .open(&path)?;
 
                     match ext {
@@ -113,6 +114,7 @@ pub fn derive_as_file(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                         let mut file = std::fs::OpenOptions::new()
                             .create(true)
                             .write(true)
+                            .truncate(true)
                             .open(&path)?;
 
                         match ext {

--- a/tests/test_derive_from_to.rs
+++ b/tests/test_derive_from_to.rs
@@ -50,6 +50,31 @@ pub fn test_derive_json() {
 }
 
 #[test]
+pub fn test_overwrite() {
+    let file = "./tests/overwrite.json";
+    let short = Field::new("short");
+    let longer = Field::new("longer");
+
+    // write longer; overwrite with short
+    longer.as_file(file).unwrap();
+    short.as_file(file).unwrap();
+    // if no truncate, then there will be an extra "}"
+    // the read fail with TrailingCharacter error.
+    let field_from_json = Field::from_file(file).unwrap();
+    assert_eq!(field_from_json.name, "short");
+    clean_up(file);
+
+    // write_pretty longer; overwrite with short
+    longer.as_file_pretty(file).unwrap();
+    short.as_file_pretty(file).unwrap();
+    // if no truncate, then there will be an extra "}"
+    // The read will fail with TrailingCharacter error.
+    let field_from_json = Field::from_file(file).unwrap();
+    assert_eq!(field_from_json.name, "short");
+    clean_up(file);
+}
+
+#[test]
 pub fn test_derive_yaml() {
     let file = "./tests/field.yaml";
     let field = Field::new("field");


### PR DESCRIPTION
I find this library handy for prototyping fragments of ideas. Thank you.

Occasionally I'd run into panics, and traced it down to write did not truncate.
If the previous write was longer, then the next read would fail with SerdeJson error TrailingCharacters.
There are 2 separate paths to be tested: regular and pretty.
Two commits: the first is adding the failing test; the second proposes a fix.
The second commit also modified Cargo.toml because the tests are in one crate and the change is in another.
Better way to package this?